### PR TITLE
Add accept header

### DIFF
--- a/src/om_sync/util.cljs
+++ b/src/om_sync/util.cljs
@@ -41,4 +41,4 @@
         (on-error {:error (.getResponseText xhr)})))
     (. xhr
       (send url (meths method) (when data (pr-str data))
-        #js {"Content-Type" "application/edn"}))))
+        #js {"Content-Type" "application/edn" "Accept" "application/edn"}))))


### PR DESCRIPTION
David,

Thanks for this useful library.

The edn-xhr helper sets the Content-Type header, but not the Accept header. If this is fixed, the library will also work seamlessly with ring-middleware-format.

Pull request to follow.
